### PR TITLE
Test boot protocol, fixed cmake file , framebuffer support and bug fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set(
         DEFAULT_QEMU_FLAGS
         -m 4G
         -bios bin/OVMF.fd
-        -drive file=bin/os.img
+        -drive file=bin/output.img
         -device VGA,edid=on,xres=1920,yres=1080
         -d int,guest_errors,cpu_reset
         -no-reboot

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CMAKE_ASM_NASM_OBJECT_FORMAT elf64)
 add_link_options(-fuse-ld=lld)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/build/bin)
-set(IMAGE_OUTPUT_NAME "os")
+set(IMAGE_OUTPUT_NAME "output")
 set(KERNEL_OUTPUT_NAME "kernel")
 
 #BOOTLOADER
@@ -28,7 +28,7 @@ add_executable(SRC_BOOTLOADER ${BOOTLOADER_FILES})
 
 set_target_properties(SRC_BOOTLOADER PROPERTIES OUTPUT_NAME BOOTX64.EFI)
 
-target_include_directories(SRC_BOOTLOADER PRIVATE src/boot/bootloader src/boot/EFI src/common)
+target_include_directories(SRC_BOOTLOADER PRIVATE src/boot/bootloader/ src/boot/EFI/ src/common/)
 
 target_compile_options(
         SRC_BOOTLOADER
@@ -41,9 +41,7 @@ target_compile_options(
         -fno-builtin-printf
         -fno-builtin-free
         -Wno-fortify-source
-        -nostdlib
-        -fno-stack-protector
-        -fno-stack-check
+        -O3
         
         )
 
@@ -51,8 +49,6 @@ target_link_options(
         SRC_BOOTLOADER
 
         PRIVATE
-        -fno-stack-protector 
-        -fno-stack-check
         -target x86_64-unknown-windows
         -nostdlib
         -Wl,-entry:EfiMain
@@ -68,14 +64,14 @@ add_executable(SRC_KERNEL ${KERNEL_FILES})
 
 set_target_properties(SRC_KERNEL PROPERTIES OUTPUT_NAME ${KERNEL_OUTPUT_NAME}.elf)
 
-target_include_directories(SRC_KERNEL PRIVATE src/kernel src/common src/boot/EFI )
+target_include_directories(SRC_KERNEL PRIVATE src/kernel src/common src/boot/EFI src/boot/bootloader/)
 
 target_compile_options(
         SRC_KERNEL
 
         PRIVATE
-        $<$<COMPILE_LANGUAGE:C CXX ASM_NASM>:
         -Wall
+        -fno-stack-protector
         -fPIC
         -mabi=sysv
         -mno-80387
@@ -87,15 +83,10 @@ target_compile_options(
         -mno-red-zone
         -mcmodel=kernel
         -fno-builtin-printf
-        -masm=intel
         -gdwarf-5
         -fno-omit-frame-pointer
         -fno-builtin-free
         -Wno-fortify-source
-        -Wno-interrupt-service-routine
-        -fno-stack-protector 
-        -fno-stack-check
-        >
 )
 
 target_link_options(
@@ -108,8 +99,6 @@ target_link_options(
         -static-pie
         -z max-page-size=0x1000
         -T ${PROJECT_SOURCE_DIR}/src/kernel/linker/kernel.ld
-        -fno-stack-protector 
-        -fno-stack-check
 )
 
 if(NOT EXISTS "bin/OVMF.fd")
@@ -123,7 +112,7 @@ add_custom_target(
         create_image
 
         ALL
-        COMMAND dd if=/dev/zero bs=1M seek=64 of=bin/${IMAGE_OUTPUT_NAME}.img bs=512 count=0
+        COMMAND dd if=/dev/zero of=bin/${IMAGE_OUTPUT_NAME}.img bs=50K count=1 status=progress
         COMMAND mformat -i bin/${IMAGE_OUTPUT_NAME}.img ::
         COMMAND mmd -i bin/${IMAGE_OUTPUT_NAME}.img ::/EFI
         COMMAND mmd -i bin/${IMAGE_OUTPUT_NAME}.img ::/EFI/BOOT
@@ -142,7 +131,7 @@ set(
         -m 4G
         -bios bin/OVMF.fd
         -drive file=bin/os.img
-        -device VGA,edid=on,xres=1920,yres=1080 
+        -device VGA,edid=on,xres=1920,yres=1080
         -d int,guest_errors,cpu_reset
         -no-reboot
         -no-shutdown

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A simple higher half x86_64 bootloader.
 mkdir build
 cd build
 cmake ..
+#either copy your OVMF image in build/bin or run cmake.. again
 cmake --build .
 ```
 ## Running the test

--- a/src/boot/EFI/efi.h
+++ b/src/boot/EFI/efi.h
@@ -1,5 +1,5 @@
-#ifndef __EFI_INCLUDE_H
-#define __EFI_INCLUDE_H
+#ifndef _EFI_INCLUDE_H
+#define _EFI_INCLUDE_H
 
 #include "efi_types.h"
 #include "efi_boot_services.h"

--- a/src/boot/EFI/efi_boot_services.h
+++ b/src/boot/EFI/efi_boot_services.h
@@ -1,5 +1,5 @@
-#ifndef __EFI_BOOT_SERVICES_H
-#define __EFI_BOOT_SERVICES_H
+#ifndef _EFI_BOOT_SERVICES_H
+#define _EFI_BOOT_SERVICES_H
 
 #include "efi.h"
 #include "efi_device_path_protocol.h"

--- a/src/boot/EFI/efi_filesystem.h
+++ b/src/boot/EFI/efi_filesystem.h
@@ -1,5 +1,5 @@
-#ifndef __EFI_FILESYSTEM_H
-#define __EFI_FILESYSTEM_H
+#ifndef _EFI_FILESYSTEM_H
+#define _EFI_FILESYSTEM_H
 
 #include <efi.h>
 
@@ -49,7 +49,7 @@ typedef struct {
 } EFI_FILE_SYSTEM_INFO;
 
 typedef struct {
-    CHAR16 VolumeLabel[];
+    CHAR16 * VolumeLabel;
 } EFI_FILE_SYSTEM_VOLUME_LABEL;
 
 typedef struct {

--- a/src/boot/EFI/efi_text_protocol.h
+++ b/src/boot/EFI/efi_text_protocol.h
@@ -1,5 +1,5 @@
-#ifndef __EFI_TEXT_PROTOCOL_H
-#define __EFI_TEXT_PROTOCOL_H
+#ifndef _EFI_TEXT_PROTOCOL_H
+#define _EFI_TEXT_PROTOCOL_H
 
 #include "efi.h"
 

--- a/src/boot/EFI/efi_types.h
+++ b/src/boot/EFI/efi_types.h
@@ -1,7 +1,8 @@
-#ifndef __EFI_TYPES_H
-#define __EFI_TYPES_H
+#ifndef _EFI_TYPES_H
+#define _EFI_TYPES_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 typedef void        VOID;
 typedef int         INT;
@@ -19,7 +20,7 @@ typedef uint64_t    UINT64;
 typedef INT64       INT128;
 typedef UINT64      UINT128;
 typedef char        CHAR8;
-typedef uint16_t    CHAR16;
+typedef wchar_t     CHAR16;
 typedef VOID       *EFI_EVENT;
 typedef VOID       *EFI_HANDLE;
 typedef uint64_t    EFI_LBA;
@@ -29,7 +30,9 @@ typedef uint64_t    EFI_TL;
 typedef uint64_t    EFI_TPL;
 typedef uint64_t    EFI_VIRTUAL_ADDRESS;
 
-#define NULL 0
+#ifndef NULL
+    #define NULL 0
+#endif
 
 #define IN 
 #define OUT 

--- a/src/boot/bootloader/bootloader.h
+++ b/src/boot/bootloader/bootloader.h
@@ -1,8 +1,7 @@
 #ifndef BOOTLOADER_H
 #define BOOTLOADER_H
 
-#include <stdint.h>
-#include "elf/elf.h"
+#include <efi.h>
 
 extern EFI_SYSTEM_TABLE * SystemTable;
 extern EFI_HANDLE   ImageHandle;

--- a/src/boot/bootloader/cpu/cpu.h
+++ b/src/boot/bootloader/cpu/cpu.h
@@ -1,7 +1,7 @@
 #ifndef EFI_CPU_H
 #define EFI_CPU_H
 
-#include <efi_types.h>
+#include <efi.h>
 
 static inline VOID SetCr3(UINT64 Value) {
     asm volatile (

--- a/src/boot/bootloader/elf/elf.h
+++ b/src/boot/bootloader/elf/elf.h
@@ -1,8 +1,7 @@
 #ifndef EFI_ELF_H
 #define EFI_ELF_H
 
-#include <efi_types.h>
-#include <efi_system.h>
+#include <efi.h>
 
 #define PT_LOAD 0x00000001
 

--- a/src/boot/bootloader/modules/gop/gop.c
+++ b/src/boot/bootloader/modules/gop/gop.c
@@ -1,6 +1,6 @@
 #include "gop.h"
+#include <efi.h>
 #include <bootloader.h>
-#include <efi_graphic_output_protocol.h>
 #include <wrappers/wrappers.h>
 #include <terminal/terminal.h>
 

--- a/src/boot/bootloader/modules/gop/gop.h
+++ b/src/boot/bootloader/modules/gop/gop.h
@@ -1,7 +1,7 @@
 #ifndef GOP_H
 #define GOP_H
 
-#include <efi_types.h>
+#include <efi.h>
 
 typedef struct {
     UINT64 FramebufferBase;

--- a/src/boot/bootloader/modules/protocols/test_boot_protocol.h
+++ b/src/boot/bootloader/modules/protocols/test_boot_protocol.h
@@ -1,0 +1,10 @@
+#ifndef TEST_BOOT_PROTOCOL_H
+#define TEST_BOOT_PROTOCOL_H
+
+#include <efi.h>
+#include <modules/gop/gop.h>
+typedef struct {
+    FramebufferInfo * Framebuffer;
+} BootInfoTest;
+
+#endif

--- a/src/boot/bootloader/paging/paging.c
+++ b/src/boot/bootloader/paging/paging.c
@@ -1,10 +1,10 @@
 #include "paging.h"
+#include <efi.h>
 #include <memory/memory.h>
 #include <terminal/terminal.h>
 #include <bootloader.h>
 #include <wrappers/wrappers.h>
 #include <cpu/cpu.h>
-#include <efi_types.h>
 
 PAGE_TABLE* Pml4 = NULL;
 UINT64 FreeEntry = 0;
@@ -18,7 +18,6 @@ PAGE_TABLE* InitPageTables(UINT8** Memory) {
     return Table;
 }
 
-// Function to map a virtual address to a physical address
 VOID MapPage(PAGE_TABLE* Pml4, UINT64 VirtualAddress, UINT64 PhysicalAddress, UINT64 Flags, UINT8** Memory) {
     int Pml4Index = (VirtualAddress >> 39) & 0x1FF;
     int PdpIndex = (VirtualAddress >> 30) & 0x1FF;
@@ -78,7 +77,7 @@ VOID SetupPaging() {
 
     EFI_MEMORY_DESCRIPTOR *LastEntry = NULL;
     for(UINTN i = MemoryMapEntriesCount-1; i>= 0; i--) {
-        LastEntry = (void *)MemoryMap + i * EfiDescriptorSize;
+        LastEntry = (VOID *)MemoryMap + i * EfiDescriptorSize;
         if( LastEntry->Type != EfiReservedMemoryType &&
             LastEntry->Type != EfiUnusableMemory &&
             LastEntry->Type != EfiMemoryMappedIO &&
@@ -100,7 +99,7 @@ VOID SetupPaging() {
     PrintIntPrefix(MemorySize/1073741824, L"Memory Size (GB): \t");
     
     for(UINTN i = 0; i < MemoryMapEntriesCount; i++) {
-        EFI_MEMORY_DESCRIPTOR *Entry = (void *)MemoryMap + i * EfiDescriptorSize;
+        EFI_MEMORY_DESCRIPTOR *Entry = (VOID *)MemoryMap + i * EfiDescriptorSize;
         if(FreeEntry == 0 && Entry->Type == EfiConventionalMemory && Entry->NumberOfPages >= PagingStructTotalCount){
             FreeEntry = (UINT64)Entry->PhysicalStart;
             goto Success;

--- a/src/boot/bootloader/paging/paging.h
+++ b/src/boot/bootloader/paging/paging.h
@@ -1,7 +1,7 @@
 #ifndef EFI_PAGING_H
 #define EFI_PAGING_H
 
-#include <efi_types.h>
+#include <efi.h>
 
 #define PAGE_SIZE 4096
 
@@ -15,5 +15,5 @@ extern PAGE_TABLE* Pml4;
 extern UINT64 FreeEntry;
 
 VOID SetupPaging();
-VOID MapPage(PAGE_TABLE* Pml4, UINT64 VirtualAddress, UINT64 PhysicalAddress, UINT64 Flags, UINT8** Memory);
+VOID MapPage(PAGE_TABLE* Pml4, UINT64 VirtualAddress, UINT64 PhysicalAddress, UINT64 Flags, UINT8** memory);
 #endif

--- a/src/boot/bootloader/terminal/terminal.c
+++ b/src/boot/bootloader/terminal/terminal.c
@@ -1,4 +1,6 @@
 #include "terminal.h"
+
+#include <efi.h>
 #include <bootloader.h>
 #include <utilities/utilities.h>
 

--- a/src/boot/bootloader/terminal/terminal.h
+++ b/src/boot/bootloader/terminal/terminal.h
@@ -1,7 +1,7 @@
 #ifndef EFI_ITOA_H
 #define EFI_ITOA_H
 
-#include <efi_types.h>
+#include <efi.h>
 
 VOID Print(CHAR16 * text);
 VOID Newline(VOID);

--- a/src/boot/bootloader/wrappers/wrappers.c
+++ b/src/boot/bootloader/wrappers/wrappers.c
@@ -11,7 +11,7 @@ VOID WaitForKeyPress() {
         SystemTable->ConIn->ReadKeyStroke(SystemTable->ConIn, &Key);
 }
 
-INT CheckError(EFI_STATUS Status, CHAR16 * ErrorMessage, CHAR16 * SuccessMessage) {
+VOID CheckError(EFI_STATUS Status, CHAR16 * ErrorMessage, CHAR16 * SuccessMessage) {
     if(Status != EFI_SUCCESS){
         SystemTable->ConOut->SetAttribute(SystemTable->ConOut, EFI_RED | EFI_BACKGROUND_BLACK);
         Print(L"Error:\t");
@@ -32,7 +32,7 @@ INT CheckError(EFI_STATUS Status, CHAR16 * ErrorMessage, CHAR16 * SuccessMessage
         Exit();
     }
     Print(SuccessMessage);
-    return EFI_SUCCESS;
+    return;
 }
 
 VOID Error(EFI_STATUS Status, CHAR16 * ErrorMessage) {

--- a/src/boot/bootloader/wrappers/wrappers.h
+++ b/src/boot/bootloader/wrappers/wrappers.h
@@ -4,8 +4,8 @@
 #include <efi_types.h>
 #include <efi_system.h>
 
-VOID WaitForKeyPress(void);
-INT CheckError(EFI_STATUS Status, CHAR16 * ErrorMessage, CHAR16 * SuccessMessage);
+VOID WaitForKeyPress(VOID);
+VOID CheckError(EFI_STATUS Status, CHAR16 * ErrorMessage, CHAR16 * SuccessMessage);
 VOID Error(EFI_STATUS Status, CHAR16 * ErrorMessage);
 VOID Exit(VOID);
 

--- a/src/common/memory/memory.c
+++ b/src/common/memory/memory.c
@@ -1,6 +1,6 @@
 #include "memory.h"
 
-VOID *memcpy(VOID *D1, CONST VOID *S1, UINTN n) {
+VOID *Memcpy(VOID *D1, CONST VOID *S1, UINTN n) {
     UINT8 *D2 = (UINT8 *)D1;
     CONST UINT8 *S2 = (CONST UINT8 *)S1;
 
@@ -77,7 +77,7 @@ INT Strcmp(CONST CHAR8 *S1, CONST CHAR8 *S2) {
 
 CHAR8 * Strrev(CHAR8 String[]) {
 	INT i, j;
-	char Temp;
+	CHAR8 Temp;
 	
 	for (i=0, j=Strlen(String)-1 ; i<j ; i++, j--) {
 		Temp = String[i];
@@ -90,7 +90,7 @@ CHAR8 * Strrev(CHAR8 String[]) {
 
 CHAR16 * Strrev16(CHAR16 String[]) {
 	INT i, j;
-	char Temp;
+	CHAR16 Temp;
 	
 	for (i=0, j=Strlen16(String)-1 ; i<j ; i++, j--) {
 		Temp = String[i];
@@ -101,8 +101,8 @@ CHAR16 * Strrev16(CHAR16 String[]) {
 	return String;
 }
 
-UINTN Strlen(const char *str) {
-	register const char *s;
+UINTN Strlen(const CHAR8 *str) {
+	register const CHAR8 *s;
 
 	for (s = str; *s; ++s);
 	return(s - str);

--- a/src/common/memory/memory.h
+++ b/src/common/memory/memory.h
@@ -3,7 +3,7 @@
 
 #include <efi_types.h>
 
-VOID *memcpy(VOID *dest, CONST VOID *src, UINTN n);
+VOID *Memcpy(VOID *dest, CONST VOID *src, UINTN n);
 VOID *Memset(VOID *s, INT c, UINTN n);
 VOID *Memmove(VOID *dest, CONST VOID *src, UINTN n);
 INT Memcmp(CONST VOID *s1, CONST VOID *s2, UINTN n);

--- a/src/common/utilities/utilities.c
+++ b/src/common/utilities/utilities.c
@@ -2,7 +2,7 @@
 #include <efi_types.h>
 #include <memory/memory.h>
 
- VOID Itoa16(INT Number, CHAR16 String[]) {
+VOID Itoa16(INT Number, CHAR16 String[]) {
      int i, Sign;
  
      if ((Sign = Number) < 0)
@@ -15,9 +15,9 @@
          String[i++] = '-';
      String[i] = '\0';
      Strrev16(String);
- }
+}
 
-  VOID Itoa(INT Number, CHAR8 String[]) {
+VOID Itoa(INT Number, CHAR8 String[]) {
      int i, Sign;
  
      if ((Sign = Number) < 0)
@@ -30,7 +30,7 @@
          String[i++] = '-';
      String[i] = '\0';
      Strrev(String);
- }
+}
 
 CHAR16* U64ToHex(UINT64 Input) {
     UINT8 Limit = 19;

--- a/src/common/utilities/utilities.h
+++ b/src/common/utilities/utilities.h
@@ -3,8 +3,9 @@
 
 #include <efi_types.h>
 
-CHAR16* U64ToHex(UINT64 Input);
-VOID Itoa(INT Number, CHAR8 String[]);
 VOID Itoa16(INT Number, CHAR16 String[]);
+VOID Itoa(INT Number, CHAR8 String[]);
+CHAR16* U64ToHex(UINT64 Input);
+
 
 #endif

--- a/src/kernel/core/kernel.c
+++ b/src/kernel/core/kernel.c
@@ -1,20 +1,13 @@
+#include <modules/protocols/test_boot_protocol.h>
 #include <serial/serial.h>
-#include <utilities/utilities.h>
 
-typedef struct {
-    UINT64 FramebufferBase;
-    UINT64 Width;
-    UINT64 Height;
-    UINT64 Pitch;
-} FramebufferInfo;
+VOID _start(BootInfoTest * BootInfo) {
+    CHAR8 String[] = "Serial Test\n";
+    SerialPrint(String);
 
-
-VOID _start(FramebufferInfo * Framebuffer) {
-    SerialPrint("\nHELLO FROM THE KERNEL!\n");
-    for (UINT16 i = 0; i < 100; i++) {
-        CHAR8 String[20];
-        Itoa(Framebuffer->Width, String);
-        SerialPrint(String);
-        SerialPrint("\n");
+    for (UINTN i = 0; i < 1000; i++) {
+        volatile UINT32 *FramebufferPointer = (UINT32 *) BootInfo->Framebuffer->FramebufferBase;
+        FramebufferPointer[i * (BootInfo->Framebuffer->Pitch) + i] = 0xFFFFFF;
     }
+    
 }


### PR DESCRIPTION
A previous bug in the cmake file which would not use the correct flags while compiling and linking has been fixed along fixed naming conventions and a test boot protocol which, for now, contains only a pointer to the struct providing information about the framebuffer.